### PR TITLE
Add functionality to show and hide an events channel

### DIFF
--- a/owenbot.cabal
+++ b/owenbot.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 52cebd42d740db21a1a555f1ff1a5797310a6153363bb586580c069ec804f413
+-- hash: 95838efa57328f18b506d22591086dcde2a461e4469b7be3451c3243a0f53365
 
 name:           owenbot
 version:        0.1.0.0
@@ -34,9 +34,9 @@ library
       Owoifier
       Status
       Utils
-      ADAPriceFetcher
       Admin
       AprilFools
+      BinancePriceFetcher
       Calc
       HallOfFame
       Helpme
@@ -44,10 +44,10 @@ library
       Inf1A
       MCServer
       Misc
+      ModifyEventsChannel
       QuoteSystem
       RoleSelfAssign
       TemplateRE
-      ModifyEventsChannel
   other-modules:
       Paths_owenbot
   hs-source-dirs:

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -168,7 +168,8 @@ emojiToUsableText r = do
 -- | `sendMessageChan` attempts to send the given `Text` in the channel with the given
 -- `channelID`. Surpesses any error message(s), returning `()`.
 sendMessageChan :: ChannelId -> T.Text -> DiscordHandler ()
-sendMessageChan c xs = void $ restCall $ R.CreateMessage c xs
+sendMessageChan c xs = do
+    void $ restCall $ R.CreateMessage c xs
 
 -- | `sendMessageChanPingsDisabled` acts in the same way as `sendMessageChan`, but disables
 -- all pings (@everyone, @user, @role) pings from the message.
@@ -186,7 +187,8 @@ sendMessageChanPingsDisabled cid t = do
 -- | `sendReply` attempts to send a reply to the given `Message`. Suppresses any error
 -- message(s), returning `()`.
 sendReply :: Message -> Bool -> T.Text -> DiscordHandler ()
-sendReply m mention xs = void $ restCall $ R.CreateMessageDetailed (messageChannel m)
+sendReply m mention xs =
+    void $ restCall $ R.CreateMessageDetailed (messageChannel m)
         $ def { R.messageDetailedContent = xs
               , R.messageDetailedReference = Just
                 $ def { referenceMessageId = Just $ messageId m }
@@ -197,7 +199,8 @@ sendReply m mention xs = void $ restCall $ R.CreateMessageDetailed (messageChann
 -- | `sendMessageChanEmbed` attempts to send the given embed with the given `Text` in the
 -- channel with the given `channelID`. Surpesses any error message(s), returning `()`.
 sendMessageChanEmbed :: ChannelId -> T.Text -> CreateEmbed -> DiscordHandler ()
-sendMessageChanEmbed c xs e = void $ restCall $ R.CreateMessageEmbed c xs e
+sendMessageChanEmbed c xs e = do
+    void $ restCall $ R.CreateMessageEmbed c xs e
 
 -- | `sendMessageDM` attempts to send the given `Text` as a direct message to the user with the
 -- given `UserId`. Surpresses any error message(s), returning `()`.
@@ -215,14 +218,8 @@ sendFileChan :: ChannelId -> T.Text -> FilePath -> DiscordHandler ()
 sendFileChan c name fp = do
     mFileContent <- liftIO $ safeReadFile fp
     case mFileContent of
-        Nothing          -> do
-<<<<<<< HEAD
-            _ <- liftIO $ putStrLn $ "[WARN] Couldn't load file: " <> fp
-=======
-            _ <- liftIO $ putStrLn $ "[WARN] couldn't read file: " <> fp
->>>>>>> cmdrefactor
-            sendMessageChan c $ owoify "The file cannot be found!"
-        Just fileContent ->
+        Nothing          -> sendMessageChan c $ owoify "The file cannot be found!"
+        Just fileContent -> do
             void $ restCall $ R.CreateMessageUploadFile c name fileContent
 
 -- | `safeReadFile` attempts to convert the file at the provided `FilePath` into a `ByteString`,

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -33,6 +33,8 @@ module Utils ( emojiToUsableText
              , captureCommandOutput
              , restart
              , update
+             , snowflakeToInt
+             , moveChannel
              ) where
 
 import qualified Discord.Requests as R
@@ -366,3 +368,9 @@ newModCommand msg cmd fun = newCommand msg cmd $ \captures -> do
 
 sendPrivError :: Message -> DiscordHandler ()
 sendPrivError msg = sendMessageDM (userId $ messageAuthor msg) $ owoify "Insufficient privileges!"
+
+snowflakeToInt :: Snowflake -> Integer
+snowflakeToInt (Snowflake w) = toInteger w
+
+moveChannel :: GuildId -> ChannelId -> Int -> DiscordHandler ()
+moveChannel guild chan location = void $ restCall $ R.ModifyGuildChannelPositions guild [(chan, location)]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -218,7 +218,9 @@ sendFileChan :: ChannelId -> T.Text -> FilePath -> DiscordHandler ()
 sendFileChan c name fp = do
     mFileContent <- liftIO $ safeReadFile fp
     case mFileContent of
-        Nothing          -> sendMessageChan c $ owoify "The file cannot be found!"
+        Nothing          -> do
+              _ <- liftIO $ putStrLn $ "[WARN] Couldn't load file: " <> fp
+              sendMessageChan c $ owoify "The file cannot be found!"
         Just fileContent -> void $ restCall $ R.CreateMessageUploadFile c name fileContent
 
 -- | `safeReadFile` attempts to convert the file at the provided `FilePath` into a `ByteString`,

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -170,8 +170,7 @@ emojiToUsableText r = do
 -- | `sendMessageChan` attempts to send the given `Text` in the channel with the given
 -- `channelID`. Surpesses any error message(s), returning `()`.
 sendMessageChan :: ChannelId -> T.Text -> DiscordHandler ()
-sendMessageChan c xs = do
-    void $ restCall $ R.CreateMessage c xs
+sendMessageChan c xs = void $ restCall $ R.CreateMessage c xs
 
 -- | `sendMessageChanPingsDisabled` acts in the same way as `sendMessageChan`, but disables
 -- all pings (@everyone, @user, @role) pings from the message.
@@ -201,8 +200,7 @@ sendReply m mention xs =
 -- | `sendMessageChanEmbed` attempts to send the given embed with the given `Text` in the
 -- channel with the given `channelID`. Surpesses any error message(s), returning `()`.
 sendMessageChanEmbed :: ChannelId -> T.Text -> CreateEmbed -> DiscordHandler ()
-sendMessageChanEmbed c xs e = do
-    void $ restCall $ R.CreateMessageEmbed c xs e
+sendMessageChanEmbed c xs e = void $ restCall $ R.CreateMessageEmbed c xs e
 
 -- | `sendMessageDM` attempts to send the given `Text` as a direct message to the user with the
 -- given `UserId`. Surpresses any error message(s), returning `()`.
@@ -221,8 +219,7 @@ sendFileChan c name fp = do
     mFileContent <- liftIO $ safeReadFile fp
     case mFileContent of
         Nothing          -> sendMessageChan c $ owoify "The file cannot be found!"
-        Just fileContent -> do
-            void $ restCall $ R.CreateMessageUploadFile c name fileContent
+        Just fileContent -> void $ restCall $ R.CreateMessageUploadFile c name fileContent
 
 -- | `safeReadFile` attempts to convert the file at the provided `FilePath` into a `ByteString`,
 -- wrapped in a `Maybe` monad. On reading failure, this function returns `Nothing`.

--- a/src/receivers/ModifyEventsChannel.hs
+++ b/src/receivers/ModifyEventsChannel.hs
@@ -34,8 +34,8 @@ moveEventsChannel :: Message -> DiscordHandler ()
 moveEventsChannel m = newModCommand m "showEvents" $ \_ -> do
     sendMessageChan (messageChannel m) $ owoify "Moving Events Channel."
 
-    eiChannelObj <- restCall $ R.GetChannel eventsChannelId
-    case eiChannelObj of 
+    eChannelObj <- restCall $ R.GetChannel eventsChannelId
+    case eChannelObj of 
         Left err -> liftIO $ print err
         Right channel -> do
             case channel of

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,9 +43,9 @@ packages:
 #
 extra-deps:
   - hoogle-5.0.18
-  # - discord-haskell-1.8.3
-  - git: https://github.com/yutotakano/discord-haskell.git
-    commit: 3c8af40b7c15715a8892395b3a9a6faf1423e604
+  - discord-haskell-1.8.6
+  # - git: https://github.com/yutotakano/discord-haskell.git
+  #   commit: 3c8af40b7c15715a8892395b3a9a6faf1423e604
   - emoji-0.1.0.2
   - hspec-2.7.4
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,16 +12,12 @@ packages:
   original:
     hackage: hoogle-5.0.18
 - completed:
-    name: discord-haskell
-    version: 1.8.3
-    git: https://github.com/yutotakano/discord-haskell.git
+    hackage: discord-haskell-1.8.6@sha256:59aa6be20aa7ee107251beb2b98a185c9b656af8afc8da8ba6737808b24f2b45,3562
     pantry-tree:
-      size: 2501
-      sha256: de15cd14685f325c7e344e8bcdcbd29e65e88341e8a0cd8edba938ebe0e9f0a3
-    commit: 3c8af40b7c15715a8892395b3a9a6faf1423e604
+      size: 2107
+      sha256: 4cc7b8f7c38a8618e0fdeba223bb1cd7bd9caca0df75016b2d866ac2a7619d82
   original:
-    git: https://github.com/yutotakano/discord-haskell.git
-    commit: 3c8af40b7c15715a8892395b3a9a6faf1423e604
+    hackage: discord-haskell-1.8.6
 - completed:
     hackage: emoji-0.1.0.2@sha256:d995572a5c7dcd28f98eb15c6e387a7b3bda1ac2477ab0d9dba8580d5d7b161f,1273
     pantry-tree:


### PR DESCRIPTION
# New Functionality
**New Mod command**: Mods will now be able to show and hide an events channel to simplify running weekly events so that the server doesn't get cluttered. 

# Added
## [Utils.hs](../blob/autoEvent/src/Utils.hs#L369)
- Added function to convert any snowflake into an integer
- Added function to move Channel to a different position in guild given guild, channel, and location
- Added handler for mod only commands
## [ModifyEventsChannel.hs](../blob/autoEvent/src/receivers/ModifyEventsChannel.hs)
- Added receiver for showEvents
- Added function that handles showing and hiding events
  - Moves the position of a category
  - Changes visibility settings for @<!-- -->everyone 
# Changes
## [Utils.hs](../blob/autoEvent/src/Utils.hs#L245)
- Changed the way Moderators are verified to accept a list of role names.
- Added error function to reduce code duplication
 

