### PR TITLE
Remove polymorphism in DiscordMonad where not needed

### DIFF
--- a/src/listeners/Academic.hs
+++ b/src/listeners/Academic.hs
@@ -47,7 +47,7 @@ padZeroes :: Int -> String -> String
 padZeroes newLen digits = replicate (newLen - length digits) '0' <> digits
 
 -- | Theorem.
-theorem :: (MonadDiscord m, MonadIO m) => Command m
+theorem :: Command DiscordHandler
 theorem =
     alias "thm"
         . help "Call an ILA theorem.\nUsage: `:theorem <theorem number>`"
@@ -64,7 +64,7 @@ theorem =
             _ -> respond m "ILA theorems have the format: XX.YY.ZZ!"
 
 -- | Definition.
-definition :: (MonadDiscord m, MonadIO m) => Command m
+definition :: Command DiscordHandler
 definition =
     alias "def"
         . help "Call an ILA definition.\nUsage: `:definition <def number>`"
@@ -80,7 +80,7 @@ definition =
                 _ -> respond m "ILA definitions have the format: XX.YY!"
 
 -- | Lemma.
-lemma :: (MonadDiscord m, MonadIO m) => Command m
+lemma :: Command DiscordHandler
 lemma =
     alias "lem"
         . help "Call an ILA lemma.\nUsage: `:lemma <lemma number>`"
@@ -95,7 +95,7 @@ lemma =
                 _ -> respond m "ILA lemmas have the format: XX.YY.ZZ!"
 
 -- | Textbook.
-textbook :: (MonadDiscord m, MonadIO m) => Command m
+textbook :: Command DiscordHandler
 textbook =
     alias "tb"
         . help
@@ -129,7 +129,7 @@ textbook =
             _ -> respond m $ "No textbook registered for `" <> subject <> "`!"
 
 -- | Syllogisms.
-syllogisms :: (MonadDiscord m, MonadIO m) => Command m
+syllogisms :: Command DiscordHandler
 syllogisms =
     alias "syl"
         . help "See the list of aristotle syllogisms!"
@@ -137,7 +137,7 @@ syllogisms =
         $ \m -> respondAsset m "id-smash-aristotle.png" "cl/syllogisms.png"
 
 -- | Booleans.
-booleans :: (MonadDiscord m, MonadIO m) => Command m
+booleans :: Command DiscordHandler
 booleans =
     alias "bool"
         . help "See the list of boolean algebra rules!"

--- a/src/listeners/Admin.hs
+++ b/src/listeners/Admin.hs
@@ -73,7 +73,7 @@ commitsAhead dir = T.pack <$> Process.readCreateProcess
     ""
 
 -- | Sends the git info to a specific channel
-sendGitInfoChan :: (MonadDiscord m, MonadIO m) => ChannelId -> m ()
+sendGitInfoChan :: ChannelId -> DiscordHandler ()
 sendGitInfoChan chan = do
     dir <- liftIO $ owenConfigRepoDir <$> readConfig
     case dir of
@@ -98,7 +98,7 @@ sendGitInfo =
     requires devPerms . command "repo" $ \m -> sendGitInfoChan $ messageChannelId m
 
 -- | Sends process instance info to a given channel
-sendInstanceInfoChan :: (MonadDiscord m, MonadIO m) => ChannelId -> m ()
+sendInstanceInfoChan :: ChannelId -> DiscordHandler ()
 sendInstanceInfoChan chan = do
     host <- liftIO getHostName
     pid  <- liftIO Process.getCurrentPid
@@ -240,7 +240,7 @@ unlock =
                             "channel is not a valid Channel (How the fuck did you pull that off?)"
 
 -- | Toggles the locking of a specified channel
-lockdownChan :: (MonadDiscord m) => ChannelId -> OverwriteId -> Lock -> m ()
+lockdownChan :: ChannelId -> OverwriteId -> Lock -> DiscordHandler ()
 lockdownChan chan guild b = do
     let switch = case b of
             Lockdown -> fst

--- a/src/listeners/HallOfFame.hs
+++ b/src/listeners/HallOfFame.hs
@@ -116,7 +116,7 @@ createHallOfFameEmbed m = do
         , createEmbedTimestamp   = Just $ messageTimestamp m
         }
 
-reactLimit :: (MonadDiscord m, MonadIO m) => Command m
+reactLimit :: Command DiscordHandler
 reactLimit =
     requires sentInServer
         . requires modPerms
@@ -150,7 +150,7 @@ readLimit limitTable = do
         then writeListDB limitTable ["1"] >> pure 1
         else pure $ read $ T.unpack $ head contents
 
-setFameChan :: (MonadDiscord m, MonadIO m) => Command m
+setFameChan :: Command DiscordHandler
 setFameChan =
     requires (sentInServer <> (modPerms <|> devPerms))
         . help "Set the channel for Hall of Fame in this server."

--- a/src/listeners/Haskell.hs
+++ b/src/listeners/Haskell.hs
@@ -86,7 +86,7 @@ codeblock lang = (("```" ++ lang ++ "\n") ++) . (++ "```")
 --
 -- >>> :pf inlineCode str = "`" ++ str ++ "`"
 -- inlineCode = ("``" ++) . (++ "``")
-pointfree :: (MonadDiscord m) => Command m
+pointfree :: Command DiscordHandler
 pointfree =
     help ("How would you write it point-free?\n" <> "Usage: `:pf <haskell expression>`")
         . command "pf"
@@ -124,7 +124,7 @@ formatHoogleEntry r =
     T.pack $ inlineCode (item r) <> " from module " <> inlineCode (name $ mdl r)
 
 -- | Searches hoogle for matching entries
-hoogle :: (MonadDiscord m, MonadIO m) => Command m
+hoogle :: Command DiscordHandler
 hoogle =
     help
             (  "See the top "

--- a/src/listeners/MCServer.hs
+++ b/src/listeners/MCServer.hs
@@ -111,7 +111,7 @@ alwaysHead :: [String] -> String
 alwaysHead []       = ""
 alwaysHead (a : as) = a
 
-getStatus :: (MonadDiscord m, MonadIO m) => Command m
+getStatus :: Command DiscordHandler
 getStatus =
     requires sentInServer
         . help
@@ -135,7 +135,7 @@ readServerIP gid = do
             >> pure "123.456.789.123"
         else pure $ head server_ip
 
-setServer :: (MonadDiscord m, MonadIO m) => Command m
+setServer :: Command DiscordHandler
 setServer =
     requires (sentInServer <> (modPerms <|> devPerms))
         . help

--- a/src/listeners/Misc.hs
+++ b/src/listeners/Misc.hs
@@ -83,7 +83,7 @@ rollCheck chance = Requirement $ \msg -> do
     welp <- ((/= 1) <$> liftIO (roll chance))
     pure $ if welp then Left "" else Right ()
 
-owoifyIfPossible :: (MonadDiscord m, MonadIO m) => Command m
+owoifyIfPossible :: Command DiscordHandler
 owoifyIfPossible =
     requires (rollCheck owoifyChance) $ regexCommand "[lLrR]|[nNmM][oO]" $ \m _ -> do
         sendReply m True $ owoify (messageContent m)
@@ -114,7 +114,7 @@ forceOwoify r = do
         -- Send reply without pinging (this isn't as ping-worthy as random trigger)
         sendReply mess False $ owoify (messageContent mess)
 
-godIsDead :: (MonadDiscord m, MonadIO m) => Command m
+godIsDead :: Command DiscordHandler
 godIsDead = regexCommand "[gG]od *[iI]s *[dD]ead" $ \m _ -> do
     base     <- liftIO assetDir
     contents <- liftIO (TIO.readFile $ base <> "nietzsche.txt")
@@ -127,11 +127,11 @@ thatcherIsDead :: (MonadDiscord m) => Command m
 thatcherIsDead = regexCommand (thatcherRE <> "[Dd]ead")
     $ \m _ -> respond m "https://www.youtube.com/watch?v=ILvd5buCEnU"
 
-thatcherIsAlive :: (MonadDiscord m, MonadIO m) => Command m
+thatcherIsAlive :: Command DiscordHandler
 thatcherIsAlive = regexCommand (thatcherRE <> "[Aa]live")
     $ \m _ -> respondAsset m "god_help_us_all.mp4" "god_help_us_all.mp4"
 
-dadJokeIfPossible :: (MonadDiscord m, MonadIO m) => Command m
+dadJokeIfPossible :: Command DiscordHandler
 dadJokeIfPossible =
     requires (rollCheck dadJokeChance)
         $ regexCommand "^[iI] ?[aA]?'?[mM] +([a-zA-Z'*]+)([!;:.,?~-]+| *$)"
@@ -159,7 +159,7 @@ fortuneCow = do
 
 -- | "Joke" function to change owen's pronouns randomly in servers on startup,
 -- cause owen is our favourite genderfluid icon.
-changePronouns :: (MonadDiscord m, MonadIO m) => m ()
+changePronouns :: DiscordHandler ()
 changePronouns = do
     u       <- getCurrentUser
     -- get partial guilds, don't contain full information, so getId is defined below
@@ -228,11 +228,11 @@ ballAnswers = map
     , "Very doubtful. "
     ]
 
-magic8ball :: (MonadDiscord m, MonadIO m) => Command m
+magic8ball :: Command DiscordHandler
 magic8ball =
     regexCommand "^:8ball.*" $ \m _ -> liftIO (select ballAnswers) >>= respond m
 
-texRender :: (MonadDiscord m) => Command m
+texRender :: Command DiscordHandler
 texRender = command "tex" $ \m (Remaining text) ->
     respond m $ (<>) "https://chart.googleapis.com/chart" $ E.decodeUtf8 $ W.renderQuery
         True

--- a/src/listeners/ModifyEventsChannel.hs
+++ b/src/listeners/ModifyEventsChannel.hs
@@ -18,7 +18,7 @@ eventsChannelId :: ChannelId
 eventsChannelId = 837700461192151120
 
 -- | Move a registered events channel to the top of the server.
-moveEventsChannel :: (MonadDiscord m) => Command m
+moveEventsChannel :: Command DiscordHandler
 moveEventsChannel = requires (sentInServer <> modPerms) $ command "showEvents" $ \m ->
     do
         respond m $ owoify "Moving Events Channel."

--- a/src/listeners/TTS.hs
+++ b/src/listeners/TTS.hs
@@ -29,7 +29,7 @@ import Owoifier
 commands :: [Command DiscordHandler]
 commands = [tts]
 
-tts :: (MonadDiscord m, MonadIO m) => Command m
+tts :: Command DiscordHandler
 tts =
     help "Speak stuff outwoud. Enclose with / to use IPA.\nUsage: `:tts <stuff>`"
         . command "tts"


### PR DESCRIPTION
My original justification for the DiscordMonad polymorphism was to make it easier to test functions from IO or pure contexts. It has been proven in the year or so since its introduction that testing IO is simply quite difficult/painful/useless, and the extra polymorphism only adds to the complexity of the type signature of functions.

By removing the polymorphism from most functions, we can reason about the code with more convenience.
We keep only the ones that strictly need to be polymorphic, like `sendQuiz` which needs to be called in scheduled IO as well as in DiscordHandler.

Some parts of the code may be reverted in the future if necessary, but that is good since it will explicitly signify that the polymorphism is required for those functions. 