### PR TITLE
Update discord-haskell to 1.13, update discord-haskell-monad to 1.2.0

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -46,7 +46,7 @@ startHandler :: OwenConfig -> DiscordHandler ()
 startHandler cfg = do
     let startupChan = owenConfigStartupChan cfg
     owenId <- call $ GetCurrentUser
-    createMessage startupChan $ T.pack "Hewwo, I am bawck! UwU"
+    call $ CreateMessage startupChan $ T.pack "Hewwo, I am bawck! UwU"
     sendGitInfoChan startupChan
     sendInstanceInfoChan startupChan
     changePronouns

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,15 +7,11 @@ import Control.Exception (SomeException)
 import Control.Monad
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import Discord
-    ( DiscordHandler
-    , RunDiscordOpts(discordOnEvent, discordOnLog, discordOnStart, discordToken)
-    , def
-    , restCall
-    , runDiscord
-    )
-import Discord.Types
 import System.Directory (createDirectoryIfMissing)
+
+import Discord
+import Discord.Requests
+import Discord.Types
 
 import Admin (sendGitInfoChan, sendInstanceInfoChan)
 import Command
@@ -49,7 +45,7 @@ handleStartErrors e = do
 startHandler :: OwenConfig -> DiscordHandler ()
 startHandler cfg = do
     let startupChan = owenConfigStartupChan cfg
-    owenId <- getCurrentUser
+    owenId <- call $ GetCurrentUser
     createMessage startupChan $ T.pack "Hewwo, I am bawck! UwU"
     sendGitInfoChan startupChan
     sendInstanceInfoChan startupChan

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  stack:

--- a/owenbot.cabal
+++ b/owenbot.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: e7769e9993163718fdc36b90449f3822abd9ea904a8e95268804a5b3e479c81a
 
 name:           owenbot
 version:        0.1.0.0
@@ -61,8 +59,8 @@ library
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.12.0
-    , discord-haskell-monad ==1.1.0
+    , discord-haskell ==1.13.0
+    , discord-haskell-monad ==1.2.0
     , html-entities
     , http-conduit
     , http-types
@@ -97,8 +95,8 @@ executable owenbot-exe
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.12.0
-    , discord-haskell-monad ==1.1.0
+    , discord-haskell ==1.13.0
+    , discord-haskell-monad ==1.2.0
     , html-entities
     , http-conduit
     , http-types
@@ -141,8 +139,8 @@ test-suite owenbot-test
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.12.0
-    , discord-haskell-monad ==1.1.0
+    , discord-haskell ==1.13.0
+    , discord-haskell-monad ==1.2.0
     , hspec
     , html-entities
     , http-conduit

--- a/owenbot.cabal
+++ b/owenbot.cabal
@@ -59,8 +59,8 @@ library
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.13.0
-    , discord-haskell-monad ==1.2.0
+    , discord-haskell ==1.14.0
+    , discord-haskell-monad ==1.2.1
     , html-entities
     , http-conduit
     , http-types
@@ -95,8 +95,8 @@ executable owenbot-exe
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.13.0
-    , discord-haskell-monad ==1.2.0
+    , discord-haskell ==1.14.0
+    , discord-haskell-monad ==1.2.1
     , html-entities
     , http-conduit
     , http-types
@@ -139,8 +139,8 @@ test-suite owenbot-test
     , bytestring
     , containers
     , directory
-    , discord-haskell ==1.13.0
-    , discord-haskell-monad ==1.2.0
+    , discord-haskell ==1.14.0
+    , discord-haskell-monad ==1.2.1
     , hspec
     , html-entities
     , http-conduit

--- a/package.yaml
+++ b/package.yaml
@@ -22,8 +22,8 @@ dependencies:
 - base64 # for decoding base64 audio in ipa tts
 - bytestring # comes with discord-haskell
 - containers # comes with discord-haskell
-- discord-haskell == 1.12.0
-- discord-haskell-monad == 1.1.0
+- discord-haskell == 1.13.0
+- discord-haskell-monad == 1.2.0
 - directory
 - html-entities
 - http-conduit

--- a/package.yaml
+++ b/package.yaml
@@ -22,8 +22,8 @@ dependencies:
 - base64 # for decoding base64 audio in ipa tts
 - bytestring # comes with discord-haskell
 - containers # comes with discord-haskell
-- discord-haskell == 1.13.0
-- discord-haskell-monad == 1.2.0
+- discord-haskell == 1.14.0
+- discord-haskell-monad == 1.2.1
 - directory
 - html-entities
 - http-conduit

--- a/src/Command/Command.hs
+++ b/src/Command/Command.hs
@@ -152,6 +152,7 @@ import UnliftIO (liftIO)
 import Discord
 import Discord.Monad
 import Discord.Types
+import qualified Discord.Requests as R
 
 import Command.Error (CommandError(..))
 import Command.Parser (ParsableArgument(..), RemainingText(..), endOrSpaces, manyTill1)
@@ -551,7 +552,7 @@ helpCommand helpName cmds onEmptyHandler = command helpName $ \msg mbName -> do
         Nothing               -> onEmptyHandler msg
         Just (Remaining name) -> if name == helpName || name == ":" <> helpName
             then
-                respond msg
+                void $ call $ R.CreateMessage (messageChannelId msg)
                 $  "**:"
                 <> helpName
                 <> "**\n"
@@ -561,7 +562,7 @@ helpCommand helpName cmds onEmptyHandler = command helpName $ \msg mbName -> do
             else do
                 let helps =
                         (map createCommandHelp . filter (cmdMatches name)) normalCmds
-                unless (null helps) $ respond msg $ T.intercalate "\n" helps
+                unless (null helps) $ void $ call $ R.CreateMessage (messageChannelId msg) $ T.intercalate "\n" helps
 
   where
     grabHelp :: Command m -> T.Text
@@ -598,14 +599,14 @@ for legibility.
 defaultErrorHandler :: (MonadDiscord m) => Message -> CommandError -> m ()
 defaultErrorHandler m e = case e of
     ArgumentParseError x ->
-        respond m $ x <> "\nCheck if `:helpme (optional command name)` can help you!"
+        void $ call $ R.CreateMessage (messageChannelId m) $ x <> "\nCheck if `:helpme (optional command name)` can help you!"
     RequirementError x -> unless (x == "") $ do
-        chan <- createDM (userId $ messageAuthor m)
-        void $ createMessage (channelId chan) x
-    ProcessingError x -> respond m x
-    DiscordError    x -> respond m $ T.pack $ "Discord request failed with a " <> show x
+        chan <- call $ R.CreateDM (userId $ messageAuthor m)
+        void $ call $ R.CreateMessage (channelId chan) x
+    ProcessingError x -> void $ call $ R.CreateMessage (messageChannelId m) x
+    DiscordError    x -> void $ call $ R.CreateMessage (messageChannelId m) $ T.pack $ "Discord request failed with a " <> show x
     HaskellError x ->
-        respond m
+        void $ call $ R.CreateMessage (messageChannelId m)
             $  owoify
             $  T.pack
             $  "Runtime error (contact OwenDev, this is a bug): "

--- a/src/Command/Parser.hs
+++ b/src/Command/Parser.hs
@@ -175,6 +175,9 @@ instance (ParsableArgument a, ParsableArgument b) => ParsableArgument (Either a 
 -----------------------------------------------------------------------------
 
 
+instance ParsableArgument (DiscordId a) where
+    parserForArg = read <$> (many1 digit <?> "a snowflake ID")
+
 instance ParsableArgument Snowflake where
     parserForArg = read <$> (many1 digit <?> "a snowflake ID")
 

--- a/src/EventHandler.hs
+++ b/src/EventHandler.hs
@@ -77,7 +77,7 @@ isFromBot m = userIsBot (messageAuthor m)
 
 handleEvent :: Event -> DiscordHandler ()
 handleEvent event = case event of
-    GuildCreate guild guildInfo ->
+    GuildCreate guild ->
         liftIO $ DB.initGuildSpecificDatabase (guildId guild)
     MessageCreate m -> unless (isFromBot m) $ do
         for_ messageReceivers ($ m) <|> pure ()

--- a/src/listeners/Academic.hs
+++ b/src/listeners/Academic.hs
@@ -14,7 +14,7 @@ import Discord.Types
 
 import Command
 import Command.Parser
-import Utils (respondAsset)
+import Utils (respondAsset, respond)
 
 commands :: [Command DiscordHandler]
 commands = [textbook, theorem, definition, lemma, syllogisms, booleans]

--- a/src/listeners/BinancePriceFetcher.hs
+++ b/src/listeners/BinancePriceFetcher.hs
@@ -14,6 +14,7 @@ import UnliftIO (liftIO)
 
 import Command
 import Owoifier (owoify)
+import Utils (respond)
 
 commands :: [Command DiscordHandler]
 commands = [handleTicker, handleAda24h]

--- a/src/listeners/HallOfFame.hs
+++ b/src/listeners/HallOfFame.hs
@@ -6,6 +6,7 @@ import Control.Monad (when)
 import Data.Maybe (fromJust)
 import qualified Data.Text as T
 import Discord
+import Discord.Requests
 import Discord.Types
 import UnliftIO (liftIO)
 
@@ -22,6 +23,7 @@ import Utils
     , pingAuthorOf
     , sendMessageChanEmbed
     , sentInServer
+    , respond
     )
 
 
@@ -157,7 +159,7 @@ setFameChan =
         $ command "setFameChan"
         $ \m chanId -> do
             let gid = fromJust (messageGuildId m)
-            c <- getChannel chanId
+            c <- call $ GetChannel chanId
             liftIO $ writeListDB (GuildDB gid "fameChannel") [T.pack $ show chanId]
             respond m
                 $  owoify

--- a/src/listeners/Haskell.hs
+++ b/src/listeners/Haskell.hs
@@ -24,6 +24,7 @@ import Network.HTTP.Simple
     )
 import Pointfree (pointfree')
 import UnliftIO (liftIO)
+import Utils (respond)
 
 commands :: [Command DiscordHandler]
 commands = [pointfree, doc, hoogle, hoogType, eval]
@@ -144,7 +145,7 @@ formatDoc r = formatHoogleEntry r <> "\n" <> T.pack (codeblock "hs" $ docs r)
 
 -- | Gives the documentation for a given Haskell function (from online Hoogle)
 -- >>> :doc map
-doc :: (MonadDiscord m, MonadIO m) => Command m
+doc :: Command DiscordHandler
 doc =
     help
             (  "See the documentation for the Haskell function.\n"
@@ -157,7 +158,7 @@ doc =
 
 -- | Gives the type of a given Haskell function (from online Hoogle, top entry)
 -- >>> :type map
-hoogType :: (MonadDiscord m, MonadIO m) => Command m
+hoogType :: Command DiscordHandler
 hoogType =
     help
             (  "See the type of the Haskell function.\n"
@@ -203,7 +204,7 @@ instance FromJSON TryHaskellResponse where
 -- Uses https://haskellmooc.co.uk/ instead of https://tryhaskell.org/ since
 -- it supports IO and looks like it's more updated.
 -- >>> :eval 1 + 1
-eval :: (MonadDiscord m, MonadIO m) => Command m
+eval :: Command DiscordHandler
 eval =
     help
             (  "Evaluate a Haskell expression.\n"

--- a/src/listeners/MCServer.hs
+++ b/src/listeners/MCServer.hs
@@ -15,7 +15,7 @@ import UnliftIO (liftIO)
 import Command
 import DB
 import Owoifier (owoify)
-import Utils (devPerms, modPerms, sentInServer)
+import Utils (devPerms, modPerms, sentInServer, respond)
 
 commands :: [Command DiscordHandler]
 commands = [getStatus, setServer]

--- a/src/listeners/Misc.hs
+++ b/src/listeners/Misc.hs
@@ -23,7 +23,7 @@ import Discord.Handle (discordHandleRestChan)
 import Discord.Internal.Rest (restHandleChan, RestCallInternalException(..))
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R
-import Discord.Internal.Rest.Prelude (baseUrl, (//), JsonRequest(..))
+import Discord.Internal.Rest.Prelude (baseUrl, JsonRequest(..))
 import Control.Monad.Reader (ask)
 import Control.Concurrent (newEmptyMVar, writeChan, readMVar)
 import Data.Aeson (object, eitherDecode, toJSON)

--- a/src/listeners/QuoteSystem.hs
+++ b/src/listeners/QuoteSystem.hs
@@ -14,7 +14,7 @@ import Command
 import DB
 import Owoifier (owoify)
 import Text.Parsec (anyChar, many1)
-import Utils (devPerms, modPerms, sendMessageChan, sentInServer)
+import Utils (devPerms, modPerms, sendMessageChan, sentInServer, respond)
 
 import System.Random
 

--- a/src/listeners/TTS.hs
+++ b/src/listeners/TTS.hs
@@ -21,10 +21,12 @@ import Network.HTTP.Simple
     , setRequestQueryString
     )
 
-import Command
 import Discord
+import Discord.Requests
 import Discord.Types
+import Command
 import Owoifier
+import Utils (respond)
 
 commands :: [Command DiscordHandler]
 commands = [tts]
@@ -45,10 +47,9 @@ tts =
                     let filename =
                             owoify $ "Amazing sounds by " <> userName (messageAuthor m)
                     let extension = if isIPA then ".mp3" else ".wav"
-                    void $ createMessageUploadFile
-                        (messageChannelId m)
-                        (filename <> extension)
-                        audio
+                    void . call $ CreateMessageDetailed (messageChannelId m) $ def
+                        { messageDetailedFile = Just (filename <> extension, audio)
+                        }
 
 -- | Download the TTS audio.
 downloadTTS :: T.Text -> IO (Maybe B.ByteString)

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,17 +42,14 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-  # - discord-haskell-1.13.0
-  # TODO update this when Hackage gets the latest updates
-  - git: https://github.com/aquarial/discord-haskell.git
-    commit: 54479e07983775522ec751289b90926bf87eab1f
+  - discord-haskell-1.14.0
   - emoji-0.1.0.2
   - hspec-2.7.8
   - pointfree-1.1.1.8
   - HMock-0.2.0.0
   - constraints-0.13 # same here
   - git: https://github.com/yutotakano/discord-haskell-monad.git
-    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
+    commit: 0170fcc178842a2f58b1d10bc81903498cb8b948
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,14 +42,17 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 extra-deps:
-  - discord-haskell-1.12.0
+  # - discord-haskell-1.13.0
+  # TODO update this when Hackage gets the latest updates
+  - git: https://github.com/aquarial/discord-haskell.git
+    commit: 54479e07983775522ec751289b90926bf87eab1f
   - emoji-0.1.0.2
   - hspec-2.7.8
   - pointfree-1.1.1.8
   - HMock-0.2.0.0
   - constraints-0.13 # same here
   - git: https://github.com/yutotakano/discord-haskell-monad.git
-    commit: f85852d53e9ff3aea4403999a06833701f59938d
+    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,16 @@
 
 packages:
 - completed:
-    hackage: discord-haskell-1.12.0@sha256:aa427494f6c1f646c9bba81b15330557b972cae4d32ff329262ce30d13b77e3e,4527
+    name: discord-haskell
+    version: 1.13.0
+    git: https://github.com/aquarial/discord-haskell.git
     pantry-tree:
-      size: 2681
-      sha256: 35edd22a7cfec04a512c1fdd7b2620674349904451d303a5cf3823ff75c45b80
+      size: 4287
+      sha256: e970cd3dddaf8a5db300263820576c29d2d4061c50b65547fd26823753dd820c
+    commit: 54479e07983775522ec751289b90926bf87eab1f
   original:
-    hackage: discord-haskell-1.12.0
+    git: https://github.com/aquarial/discord-haskell.git
+    commit: 54479e07983775522ec751289b90926bf87eab1f
 - completed:
     hackage: emoji-0.1.0.2@sha256:d995572a5c7dcd28f98eb15c6e387a7b3bda1ac2477ab0d9dba8580d5d7b161f,1273
     pantry-tree:
@@ -48,15 +52,15 @@ packages:
     hackage: constraints-0.13
 - completed:
     name: discord-haskell-monad
-    version: 1.1.0
+    version: 1.2.0
     git: https://github.com/yutotakano/discord-haskell-monad.git
     pantry-tree:
-      size: 506
-      sha256: c38654057f28f9f0814bd3d21626c886c974099edaa2f5447b0b96c9279521cb
-    commit: f85852d53e9ff3aea4403999a06833701f59938d
+      size: 557
+      sha256: 7cb9116f86636354357f6c8f4ee1a1c456316bc18891c5826b827ca58a1187cf
+    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
   original:
     git: https://github.com/yutotakano/discord-haskell-monad.git
-    commit: f85852d53e9ff3aea4403999a06833701f59938d
+    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
 snapshots:
 - completed:
     size: 587821

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,16 +5,12 @@
 
 packages:
 - completed:
-    name: discord-haskell
-    version: 1.13.0
-    git: https://github.com/aquarial/discord-haskell.git
+    hackage: discord-haskell-1.14.0@sha256:29e94370c861952a39a1d136decc6577e6f65d9ec582d98f33df09b6ad547216,3927
     pantry-tree:
-      size: 4287
-      sha256: e970cd3dddaf8a5db300263820576c29d2d4061c50b65547fd26823753dd820c
-    commit: 54479e07983775522ec751289b90926bf87eab1f
+      size: 2847
+      sha256: 9eb535ef65bdd7e44a696d5196a15826e7096be3c386c382e841753e3c895846
   original:
-    git: https://github.com/aquarial/discord-haskell.git
-    commit: 54479e07983775522ec751289b90926bf87eab1f
+    hackage: discord-haskell-1.14.0
 - completed:
     hackage: emoji-0.1.0.2@sha256:d995572a5c7dcd28f98eb15c6e387a7b3bda1ac2477ab0d9dba8580d5d7b161f,1273
     pantry-tree:
@@ -52,15 +48,15 @@ packages:
     hackage: constraints-0.13
 - completed:
     name: discord-haskell-monad
-    version: 1.2.0
+    version: 1.2.1
     git: https://github.com/yutotakano/discord-haskell-monad.git
     pantry-tree:
-      size: 557
-      sha256: 7cb9116f86636354357f6c8f4ee1a1c456316bc18891c5826b827ca58a1187cf
-    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
+      size: 558
+      sha256: 1fda3ec86ed7ea9a2ee6195b65eed0d08c71514482aad34ce7bcf9ae52d3056d
+    commit: 0170fcc178842a2f58b1d10bc81903498cb8b948
   original:
     git: https://github.com/yutotakano/discord-haskell-monad.git
-    commit: e8b9d41d1d41cd296140fdfc73924fa74f9a4ef2
+    commit: 0170fcc178842a2f58b1d10bc81903498cb8b948
 snapshots:
 - completed:
     size: 587821


### PR DESCRIPTION
This PR updates discord-haskell to 1.13, and the small discord-haskell-monad library that I made a while back to 1.2.0.

Not ready to merge, waiting for discord-haskell to update to 1.13.1 since we have changes relying on the most recent master commits.

This also fixes the issue plaguing Owen recently where Parse Errors cause a library crash.

## Changes

All `restCall` changed to `call`, and should be the preferred way forward (this throws errors as exceptions instead of returning Either)
The DiscordMonad typeclass doesn't contain all the functions anymore (since it was difficult to keep track which functions were local and which were defined in the class), it only contains `call`.

Basically stuff like this, but throughout the entire codebase:
```diff
- allGuildRoles <- getGuildRoles g
- user          <- getGuildMember g uid
+ allGuildRoles <- call $ GetGuildRoles g
+ user          <- call $ GetGuildMember g uid
```

Also fixes some new issues introduced by 1.13, like Snowflake parsing with commands, and shortened Interaction Commands datatype names.